### PR TITLE
Fix build on case-sensitive file systems

### DIFF
--- a/cpp/applicationui.hpp
+++ b/cpp/applicationui.hpp
@@ -9,7 +9,7 @@
 #include "gen/SettingsData.hpp"
 #include "gen/DataManager.hpp"
 #include "dataserver.hpp"
-#include "DataUtil.hpp"
+#include "datautil.hpp"
 
 class ApplicationUI : public QObject
 {


### PR DESCRIPTION
```
In file included from cpp/main.cpp:8:0:
cpp/applicationui.hpp:12:24: fatal error: DataUtil.hpp: No such file or directory
```
